### PR TITLE
Tell the user how long the field can be

### DIFF
--- a/stanford_fields.module
+++ b/stanford_fields.module
@@ -31,6 +31,7 @@ function stanford_fields_field_storage_add_validate(&$form, FormStateInterface $
   // down exactly what table is for what field without inspecting the field
   // storage config entity.
   if (strlen("{$entity_type}_revision__{$field_prefix}$field_name") > 48) {
-    $form_state->setError($form['new_storage_wrapper']['field_name'], t('Field name is too long. Please keep this field name under @count characters'));
+    $allowed_length = 48 - strlen("{$entity_type}_revision__{$field_prefix}");
+    $form_state->setError($form['new_storage_wrapper']['field_name'], t('Field name is too long. Please keep this field name under @count characters', ['@count' => $allowed_length]));
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed the error that is presented to the user.

# Need Review By (Date)
- whenever

# Urgency
- low

# Steps to Test
1. checkout this branch.
1. in a paragraph type, attempt to add a field with a long machine name.
1. validate the error gives you the number of characters allowed.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
