### PR TITLE
D8CORE-106: Media with caption paragraph

### DIFF
--- a/src/Plugin/Field/FieldFormatter/MultiMedia.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMedia.php
@@ -2,12 +2,27 @@
 
 namespace Drupal\stanford_fields\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\media\Entity\Media;
-use Drupal\file\Entity\File;
 use Drupal\Core\Url;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
+use Drupal\media\Entity\MediaType;
+use Drupal\media\IFrameUrlHelper;
+use Drupal\media\OEmbed\Resource;
+use Drupal\media\OEmbed\ResourceException;
+use Drupal\media\OEmbed\ResourceFetcherInterface;
+use Drupal\media\OEmbed\UrlResolverInterface;
+use Drupal\media\Plugin\media\Source\OEmbedInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the 'multimedia' formatter.
@@ -20,7 +35,122 @@ use Drupal\Core\Url;
  *   }
  * )
  */
-class MultiMedia extends FormatterBase {
+class MultiMedia extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The oEmbed resource fetcher.
+   *
+   * @var \Drupal\media\OEmbed\ResourceFetcherInterface
+   */
+  protected $resourceFetcher;
+
+  /**
+   * The oEmbed URL resolver service.
+   *
+   * @var \Drupal\media\OEmbed\UrlResolverInterface
+   */
+  protected $urlResolver;
+
+  /**
+   * The logger service.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * The media settings config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * The iFrame URL helper service.
+   *
+   * @var \Drupal\media\IFrameUrlHelper
+   */
+  protected $iFrameUrlHelper;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs an OEmbedFormatter instance.
+   *
+   * @param string $plugin_id
+   *   The plugin ID for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   * @param \Drupal\media\OEmbed\ResourceFetcherInterface $resource_fetcher
+   *   The oEmbed resource fetcher service.
+   * @param \Drupal\media\OEmbed\UrlResolverInterface $url_resolver
+   *   The oEmbed URL resolver service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\media\IFrameUrlHelper $iframe_url_helper
+   *   The iFrame URL helper service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, MessengerInterface $messenger, ResourceFetcherInterface $resource_fetcher, UrlResolverInterface $url_resolver, LoggerChannelFactoryInterface $logger_factory, ConfigFactoryInterface $config_factory, IFrameUrlHelper $iframe_url_helper, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+    $this->messenger = $messenger;
+    $this->resourceFetcher = $resource_fetcher;
+    $this->urlResolver = $url_resolver;
+    $this->logger = $logger_factory->get('media');
+    $this->config = $config_factory->get('media.settings');
+    $this->iFrameUrlHelper = $iframe_url_helper;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('messenger'),
+      $container->get('media.oembed.resource_fetcher'),
+      $container->get('media.oembed.url_resolver'),
+      $container->get('logger.factory'),
+      $container->get('config.factory'),
+      $container->get('media.oembed.iframe_url_helper'),
+      $container->get('entity_type.manager')
+    );
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -37,7 +167,12 @@ class MultiMedia extends FormatterBase {
     return [
       // Declare a setting named 'text_length', with
       // a default value of 'short'
-      'text_length' => 'short',
+      'image_formatter' => 'responsive',
+      'image_formatter_option' => 'large',
+      'video_formatter' => 'oembed',
+      'video_formatter_option' => 'default',
+      'video_formatter_height' => 0,
+      'video_formatter_width' => 0,
     ] + parent::defaultSettings();
   }
 
@@ -68,7 +203,7 @@ class MultiMedia extends FormatterBase {
       '#title' => $this->t('Video Formatter'),
       '#type' => 'select',
       '#options' => [
-        'oembed' => $this->t('Oembed'),
+        'oembed' => $this->t('oEmbed Content'),
         'rendered' => $this->t('Rendered entity'),
       ],
       '#default_value' => $this->getSetting('video_formatter'),
@@ -77,8 +212,22 @@ class MultiMedia extends FormatterBase {
     $form['video_formatter_option'] = [
       '#title' => $this->t('Video Formatter Setting'),
       '#type' => 'textfield',
-      '#default_value' => $this->getSetting('image_formatter_option'),
+      '#default_value' => $this->getSetting('video_formatter_option'),
       '#description' => $this->t('The machine name key for the display mode, style, etc.'),
+    ];
+
+    $form['video_formatter_height'] = [
+      '#title' => $this->t('Video Max Height (px)'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('video_formatter_height'),
+      '#description' => $this->t('Integer value for max height.'),
+    ];
+
+    $form['video_formatter_width'] = [
+      '#title' => $this->t('Video Max Width (px)'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('video_formatter_width'),
+      '#description' => $this->t('Integer value for max width.'),
     ];
 
     return $form;
@@ -90,24 +239,197 @@ class MultiMedia extends FormatterBase {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
     foreach ($items as $delta => $item) {
-      // Get the media item.
+    // Get the media item.
       $media_id = $item->getValue()['target_id'];
       $media_item = Media::load($media_id);
-      // Get the file.
-      $file_id = $media_item->field_media_file->getValue()[0]['target_id'];
-      $file = File::load($file_id);
-      // Get the URL.
-      $uri = $file->getFileUri();
-      $url = Url::fromUri(file_create_url($uri))->toString();
-      // Output.
-      $elements[$delta] = [
-        '#type'     => 'inline_template',
-        '#template' => '<a href="{{ url }}" target="_blank">Download Slides</a>',
-        '#context'  => [
-          'url' => $url,
-        ],
-      ];
+      $type = $media_item->bundle();
+
+      // Depending on the type of media referenced
+      switch ($type) {
+        case 'image':
+          $elements[$delta] = $this->viewImageElement($item, $media_item);
+          break;
+
+        case 'video':
+          $elements[$delta] = $this->viewVideoElement($item, $media_item);
+          break;
+
+        default:
+          $elements[$delta] = $this->viewDefaultElement($item, $media_item);
+      }
     }
+
     return $elements;
   }
+
+  /**
+   * Generates render arrays for the different image media type options.
+   *
+   * @param object $item
+   *   A single item from the FieldItemList object.
+   * @param \Drupal\media\Entity\Media $media
+   *   An instantiated Media Object.
+   *
+   * @return array
+   *   A render array.
+   */
+  private function viewImageElement($item, $media) {
+    $fid = $media->get('thumbnail')[0]->get('target_id')->getValue();
+    $height = $media->get('thumbnail')[0]->get('height')->getValue();
+    $width = $media->get('thumbnail')[0]->get('width')->getValue();
+    $file = File::load($fid);
+    $formatter = $this->getSetting('image_formatter');
+    $opt = $this->getSetting('image_formatter_option');
+    $element = [];
+
+    // Create a render array based on the setting selected by the site builder.
+    switch ($formatter) {
+      case 'responsive':
+        $element = [
+          '#theme' => 'responsive_image',
+          '#width' => $height,
+          '#height' => $width,
+          '#responsive_image_style_id' => $opt,
+          '#uri' => $file->getFileUri(),
+        ];
+        break;
+
+      case 'static':
+        $element = [
+          '#theme' => 'image_style',
+          '#width' => $height,
+          '#height' => $width,
+          '#style_name' => $opt,
+          '#uri' => $file->getFileUri(),
+        ];
+        break;
+
+      default: // render
+        $element = $this->viewDefaultElement($item, $media, $this->getSetting('image_formatter_option'));
+    }
+
+    return $element;
+  }
+
+  /**
+   * Generate a render array for a Video media element.
+   *
+   * @param object $item
+   *   A single item from the FieldItemList object.
+   * @param \Drupal\media\Entity\Media $media
+   *   An instantiated Media Object.
+   *
+   * @return array
+   *   A render array.
+   */
+  private function viewVideoElement($item, $media) {
+    $element = [];
+    $max_width = $this->getSetting('video_formatter_width');
+    $max_height= $this->getSetting('video_formatter_height');
+
+    // As there are only two options right now if they user doesn't select
+    // oembed default to the render view mode option.
+    if ($this->getSetting("video_formatter") !== "oembed") {
+      return $this->viewDefaultElement($item, $media, $this->getSetting('video_formatter_option'));
+    }
+
+    // Oembed render.
+    // Most of the below code has been taken from
+    // Drupal\media\Plugin\Field\FieldFormatter\OEmbedFormatter
+    // It has been slightly modified to suit our needs.
+    $value = $media->get("field_media_oembed_video")->getValue()[0]['value'];
+
+    try {
+      $resource_url = $this->urlResolver->getResourceUrl($value, $max_width, $max_height);
+      $resource = $this->resourceFetcher->fetchResource($resource_url);
+    }
+    catch (ResourceException $exception) {
+      $this->logger->error("Could not retrieve the remote URL (@url).", ['@url' => $value]);
+      return;
+    }
+
+    if ($resource->getType() === Resource::TYPE_LINK) {
+      $element = [
+        '#title' => $resource->getTitle(),
+        '#type' => 'link',
+        '#url' => Url::fromUri($value),
+      ];
+    }
+    elseif ($resource->getType() === Resource::TYPE_PHOTO) {
+      $element = [
+        '#theme' => 'image',
+        '#uri' => $resource->getUrl()->toString(),
+        '#width' => $max_width ?: $resource->getWidth(),
+        '#height' => $max_height ?: $resource->getHeight(),
+      ];
+    }
+    else {
+      $url = Url::fromRoute('media.oembed_iframe', [], [
+        'query' => [
+          'url' => $value,
+          'max_width' => $max_width,
+          'max_height' => $max_height,
+          'hash' => $this->iFrameUrlHelper->getHash($value, $max_width, $max_height),
+        ],
+      ]);
+
+      $domain = $this->config->get('iframe_domain');
+      if ($domain) {
+        $url->setOption('base_url', $domain);
+      }
+
+      // Render videos and rich content in an iframe for security reasons.
+      // @see: https://oembed.com/#section3
+      $element = [
+        '#type' => 'html_tag',
+        '#tag' => 'iframe',
+        '#attributes' => [
+          'src' => $url->toString(),
+          'frameborder' => 0,
+          'scrolling' => FALSE,
+          'allowtransparency' => TRUE,
+          'width' => $max_width ?: $resource->getWidth(),
+          'height' => $max_height ?: $resource->getHeight(),
+          'class' => ['media-oembed-content'],
+        ],
+        '#attached' => [
+          'library' => [
+            'media/oembed.formatter',
+          ],
+        ],
+      ];
+
+      // An empty title attribute will disable title inheritance, so only
+      // add it if the resource has a title.
+      $title = $resource->getTitle();
+      if ($title) {
+        $element['#attributes']['title'] = $title;
+      }
+
+      CacheableMetadata::createFromObject($resource)
+        ->addCacheTags($this->config->getCacheTags())
+        ->applyTo($element);
+    }
+
+    return $element;
+  }
+
+  /**
+   * Use view modes to generate a render array.
+   *
+   * @param object $item
+   *   A single item from the FieldItemList object.
+   * @param \Drupal\media\Entity\Media $media
+   *   An instantiated Media Object.
+   * @param string $view_mode
+   *   The view mode machine name.
+   *
+   * @return array
+   *   A render array for a view mode.
+   */
+  private function viewDefaultElement($item, $media, $view_mode = "default") {
+    $build = $this->entityTypeManager->getViewBuilder('media')->view($media, $view_mode);
+    return $build;
+  }
+
 }

--- a/src/Plugin/Field/FieldFormatter/MultiMedia.php
+++ b/src/Plugin/Field/FieldFormatter/MultiMedia.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\stanford_fields\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\media\Entity\Media;
+use Drupal\file\Entity\File;
+use Drupal\Core\Url;
+
+/**
+ * Plugin implementation of the 'multimedia' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "multimedia",
+ *   label = @Translation("Multiple Media Formatter"),
+ *   field_types = {
+ *     "entity_reference"
+ *   }
+ * )
+ */
+class MultiMedia extends FormatterBase {
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $summary[] = $this->t('Too many things to show you. Open up the settings to see.');
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      // Declare a setting named 'text_length', with
+      // a default value of 'short'
+      'text_length' => 'short',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+
+    $form['image_formatter'] = [
+      '#title' => $this->t('Image Formatter'),
+      '#type' => 'select',
+      '#options' => [
+        'responsive' => $this->t('Media Responsive Image Style '),
+        'static' => $this->t('Media Image Style'),
+        'rendered' => $this->t('Rendered entity'),
+      ],
+      '#default_value' => $this->getSetting('image_formatter'),
+    ];
+
+    $form['image_formatter_option'] = [
+      '#title' => $this->t('Image Formatter Setting'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('image_formatter_option'),
+      '#description' => $this->t('The machine name key for the display mode, style, etc.'),
+    ];
+
+    $form['video_formatter'] = [
+      '#title' => $this->t('Video Formatter'),
+      '#type' => 'select',
+      '#options' => [
+        'oembed' => $this->t('Oembed'),
+        'rendered' => $this->t('Rendered entity'),
+      ],
+      '#default_value' => $this->getSetting('video_formatter'),
+    ];
+
+    $form['video_formatter_option'] = [
+      '#title' => $this->t('Video Formatter Setting'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('image_formatter_option'),
+      '#description' => $this->t('The machine name key for the display mode, style, etc.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $delta => $item) {
+      // Get the media item.
+      $media_id = $item->getValue()['target_id'];
+      $media_item = Media::load($media_id);
+      // Get the file.
+      $file_id = $media_item->field_media_file->getValue()[0]['target_id'];
+      $file = File::load($file_id);
+      // Get the URL.
+      $uri = $file->getFileUri();
+      $url = Url::fromUri(file_create_url($uri))->toString();
+      // Output.
+      $elements[$delta] = [
+        '#type'     => 'inline_template',
+        '#template' => '<a href="{{ url }}" target="_blank">Download Slides</a>',
+        '#context'  => [
+          'url' => $url,
+        ],
+      ];
+    }
+    return $elements;
+  }
+}

--- a/stanford_fields.schema.yml
+++ b/stanford_fields.schema.yml
@@ -1,0 +1,16 @@
+field.formatter.settings.multimedia:
+  type: mapping
+  label: 'Multiple Media Field Formatter'
+  mapping:
+    image_formatter:
+      type: string
+      label: 'Image Formatter'
+    image_formatter_option:
+      type: string
+      label: 'Image Formatter Option'
+    video_formatter:
+      type: string
+      label: 'Video Formatter'
+    video_formatter_option:
+      type: string
+      label: 'Video Formatter Option'

--- a/stanford_fields.schema.yml
+++ b/stanford_fields.schema.yml
@@ -14,3 +14,9 @@ field.formatter.settings.multimedia:
     video_formatter_option:
       type: string
       label: 'Video Formatter Option'
+    video_formatter_height:
+      type: integer
+      label: 'Max Video Height'
+    video_formatter_width:
+      type: integer
+      label: 'Max Video Width'

--- a/tests/src/Unit/Plugin/Field/FieldFormatter/MultiMedia.php
+++ b/tests/src/Unit/Plugin/Field/FieldFormatter/MultiMedia.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\Tests\stanford_fields\Unit\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\Url;
+use Drupal\stanford_fields\Plugin\Field\FieldFormatter\EntityTitleHeading;
+
+/**
+ * Class EntityTitleHeadingTest
+ *
+ * @group stanford_fields
+ * @coversDefaultClass \Drupal\stanford_fields\Plugin\Field\FieldFormatter\EntityTitleHeading
+ */
+class MultiMediaTest extends FieldFormatterTestBase {
+
+  /**
+   * Field formatter plugin.
+   *
+   * @var \Drupal\stanford_fields\Plugin\Field\FieldFormatter\EntityTitleHeading
+   */
+  protected $plugin;
+
+  /**
+   * Mock field item list.
+   *
+   * @var \Drupal\Core\Field\FieldItemListInterface
+   */
+  protected $fieldItemList;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+
+    $parent_entity = $this->createMock(FieldableEntityInterface::class);
+    $parent_entity->method('toUrl')->willReturn(Url::fromUserInput('/foo-bar'));
+
+    $parent = $this->createMock(TraversableTypedDataInterface::class);
+    $parent->method('getValue')->willReturn($parent_entity);
+
+    $this->fieldItemList = $this->createMock(FieldItemListInterface::class);
+    $this->fieldItemList->method('getParent')->willReturn($parent);
+    $this->fieldItemList->method('getValue')
+      ->willReturn([['value' => 'Foo Bar']]);
+
+    $configuration = [
+      'field_definition' => $field_definition,
+      'settings' => [],
+      'label' => 'Foo',
+      'view_mode' => 'default',
+      'third_party_settings' => [],
+    ];
+    $this->plugin = EntityTitleHeading::create($this->container, $configuration, '', []);
+  }
+
+  public function testPluginSettings() {
+
+    // $this->assertArrayEquals([
+    //   'tag' => 'h2',
+    //   'linked' => FALSE,
+    // ], EntityTitleHeading::defaultSettings());
+    //
+    // $form = [];
+    // $form_state = new FormState();
+    // $element = $this->plugin->settingsForm($form, $form_state);
+    // $this->assertArrayEquals([
+    //   'h1' => 'H1',
+    //   'h2' => 'H2',
+    //   'h3' => 'H3',
+    //   'h4' => 'H4',
+    //   'h5' => 'H5',
+    // ], $element['tag']['#options']);
+    //
+    // $summary = $this->plugin->settingsSummary();
+    // $this->assertNotEmpty($summary);
+    // $this->assertEquals('Header level: h2', reset($summary)->render());
+  }
+
+  public function testViewElements() {
+
+    // $this->plugin->setSetting('tag', 'h2');
+    // $output = $this->plugin->viewElements($this->fieldItemList, 'en');
+    // $this->assertEquals('h2', $output[0]['#tag']);
+    // $this->assertEquals('html_tag', $output[0]['#type']);
+    // $this->assertEquals('Foo Bar', $output[0]['#value']);
+    //
+    // $this->plugin->setSetting('tag', 'h1');
+    // $output = $this->plugin->viewElements($this->fieldItemList, 'en');
+    // $this->assertEquals('h1', $output[0]['#tag']);
+    // $this->assertEquals('html_tag', $output[0]['#type']);
+    // $this->assertEquals('Foo Bar', $output[0]['#value']);
+    //
+    // $this->isFrontPage = TRUE;
+    // $output = $this->plugin->viewElements($this->fieldItemList, 'en');
+    // $this->assertEmpty($output);
+  }
+
+  public function testLinkedViewElements() {
+    // $this->plugin->setSetting('tag', 'h2');
+    // $this->plugin->setSetting('linked', TRUE);
+    // $output = $this->plugin->viewElements($this->fieldItemList, 'en');
+    // $this->assertEquals('<a href="/foo-bar">Foo Bar</a>', $output[0]['#value']);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds field_formatter to handle an entity reference field to media entities and multiple bundles.
- Support for images and video
- Images can render as (responsive image style, static image style, rendered entity)
- Video can render as (oembed or rendered entity)
- TODO: Need to flush out the tests

# Review By (Date)
- January 15th

# Urgency
- Low

# Steps to Test

1. See https://github.com/SU-SWS/acsf-cardinalsites/pull/51

# Affected Projects or Products
- D8CORE
- stanford_profile

# Associated Issues and/or People
- D8CORE-106
- @imonroe FYI

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)