### PR TITLE
CSD-79 Created a date only widget for datetime fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 ## Defines images and working directory.
 defaults: &defaults
   docker:
-    - image: pookmish/drupal8ci:latest
+    - image: pookmish/drupal8ci:pcov
     - image: selenium/standalone-chrome:3.141.59-neon
     - image: mariadb:10.3
       environment:

--- a/config/schema/stanford_fields.schema.yml
+++ b/config/schema/stanford_fields.schema.yml
@@ -1,0 +1,19 @@
+field.widget.settings.datetime_year_only:
+  type: mapping
+  label: 'Year Only Date widget settings'
+  mapping:
+    increment:
+      type: integer
+      label: 'Time increments'
+    date_order:
+      type: string
+      label: 'Date part order'
+    time_type:
+      type: string
+      label: 'Time type'
+    start:
+      type: integer
+      label: 'Start Year'
+    end:
+      type: integer
+      label: 'End Year'

--- a/src/Plugin/Field/FieldWidget/DateYearOnlyWidget.php
+++ b/src/Plugin/Field/FieldWidget/DateYearOnlyWidget.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\stanford_fields\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\datetime\Plugin\Field\FieldWidget\DateTimeDatelistWidget;
+
+/**
+ * Plugin to provide a date widget that only collects the year.
+ *
+ * @FieldWidget(
+ *   id = "datetime_year_only",
+ *   label = @Translation("Year Only"),
+ *   field_types = {
+ *     "datetime"
+ *   }
+ * )
+ */
+class DateYearOnlyWidget extends DateTimeDatelistWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $ten_years = 60 * 60 * 24 * 365 * 10;
+    $settings = [
+      'start' => date('Y', time() - $ten_years),
+      'end' => date('Y', time() + $ten_years),
+    ];
+    return $settings + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $summary[] = t('Years @start to @end', [
+      '@start' => $this->getSetting('start'),
+      '@end' => $this->getSetting('end'),
+    ]);
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element = parent::settingsForm($form, $form_state);
+    $element['date_order']['#type'] = 'hidden';
+
+    $year_range = range(1900, 2100);
+    $element['start'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Start Year'),
+      '#options' => array_combine($year_range, $year_range),
+      '#default_value' => $this->getSetting('start'),
+    ];
+    $element['end'] = [
+      '#type' => 'select',
+      '#title' => $this->t('End Year'),
+      '#options' => array_combine($year_range, $year_range),
+      '#default_value' => $this->getSetting('end'),
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    $element['value']['#date_part_order'] = ['year'];
+    $element['value']['#date_year_range'] = $this->getSetting('start') . ':' . $this->getSetting('end');
+    return $element;
+  }
+
+}

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\stanford_fields\Kernel\Plugin\Field\FieldFormatter;
+namespace Drupal\Tests\stanford_fields\Kernel\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Field\FieldDefinitionInterface;

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\Tests\stanford_fields\Kernel\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget;
+
+/**
+ * Class DateYearOnlyWidgetTest
+ *
+ * @group
+ * @coversDefaultClass \Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget
+ */
+class DateYearOnlyWidgetTest extends KernelTestBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  protected static $modules = [
+    'system',
+    'path_alias',
+    'node',
+    'user',
+    'datetime',
+    'stanford_fields',
+    'field',
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('field_config');
+    $this->installEntitySchema('date_format');
+
+    NodeType::create(['type' => 'page'])->save();
+
+    $field_storage = FieldStorageConfig::create([
+      'field_name' => 'field_date',
+      'entity_type' => 'node',
+      'type' => 'datetime',
+      'cardinality' => 1,
+    ]);
+    $field_storage->save();
+
+    $field = FieldConfig::create([
+      'field_name' => 'field_date',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+    ]);
+    $field->save();
+  }
+
+  /**
+   * Test the entity form is displayed correctly.
+   */
+  public function testWidgetForm() {
+    $node = Node::create([
+      'type' => 'page',
+    ]);
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+    $entity_form_display = EntityFormDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'page',
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+    $entity_form_display->setComponent('field_date', ['type' => 'datetime_year_only'])
+      ->removeComponent('created')
+      ->save();
+
+    $form = [];
+    $form_state = new FormState();
+
+    $entity_form_display->buildForm($node, $form, $form_state);
+
+    $widget_value = $form['field_date']['widget'][0]['value'];
+    $ten_years = 60 * 60 * 24 * 365 * 10;
+    $range = date('Y', time() - $ten_years) . ':' . date('Y', time() + $ten_years);
+
+    $this->assertEqual('datelist', $widget_value['#type']);
+    $this->assertEqual($range, $widget_value['#date_year_range']);
+  }
+
+  /**
+   * Test the settings form and the summary.
+   */
+  public function testSettingsForm() {
+    $field_def = $this->createMock(FieldDefinitionInterface::class);
+    $config = [
+      'field_definition' => $field_def,
+      'settings' => [],
+      'third_party_settings' => [],
+    ];
+    $definition = [];
+    $widget = DateYearOnlyWidget::create(\Drupal::getContainer(), $config, '', $definition);
+    $summary = 'Years 2010 to 2030';
+    $this->assertEqual($summary, $widget->settingsSummary()[0]);
+
+    $form = [];
+    $form_state = new FormState();
+    $element = $widget->settingsForm($form, $form_state);
+
+    $ten_years = 60 * 60 * 24 * 365 * 10;
+
+    $this->assertEqual(date('Y', time() - $ten_years), $element['start']['#default_value']);
+    $this->assertEqual(date('Y', time() + $ten_years), $element['end']['#default_value']);
+  }
+
+}

--- a/tests/src/Unit/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
+++ b/tests/src/Unit/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\stanford_fields\Unit\Plugin\Field\FieldFormatter;
+namespace Drupal\Tests\stanford_fields\Unit\Plugin\Field\FieldWidget;
 
 use Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget;
 use Drupal\Tests\UnitTestCase;

--- a/tests/src/Unit/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
+++ b/tests/src/Unit/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\Tests\stanford_fields\Unit\Plugin\Field\FieldFormatter;
+
+use Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class DateYearOnlyWidgetTest
+ *
+ * @group
+ * @coversDefaultClass \Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget
+ */
+class DateYearOnlyWidgetTest extends UnitTestCase {
+
+  public function testDefaultSettings() {
+    $default_settings = DateYearOnlyWidget::defaultSettings();
+    $ten_years = (60 * 60 * 24 * 365 * 10);
+    $expected = [
+      'date_order' => 'YMD',
+      'increment' => '15',
+      'time_type' => '24',
+      'start' => date('Y', time() - $ten_years),
+      'end' => date('Y', time() + $ten_years),
+    ];
+    $this->assertArrayEquals($expected, $default_settings);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a "Year Only" date widget. data in the database is stored as 1/1 12:00 AM for the given year. its up to the formatter to display only the year.
- This differs from https://www.drupal.org/project/yearonly in the way it stores the data. the contrib module just stores an integer and it can not be used as relative date sorting

# Need Review By (Date)
- 3/25

# Urgency
- medium

# Steps to Test
1. Checkout this branch
1. clear caches
1. create a data field
1. on the form display settings, set the widget to be "Year only"
1. verify when you see the widget on entity creation, you only get a year input.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
