### PR TITLE
Release 8.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 ## Defines images and working directory.
 defaults: &defaults
   docker:
-    - image: pookmish/drupal8ci:latest
+    - image: pookmish/drupal8ci:pcov
     - image: selenium/standalone-chrome:3.141.59-neon
     - image: mariadb:10.3
       environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,16 +57,38 @@ behat: &behat
     - store_artifacts:
         path: /var/www/html/artifacts
 
+back_to_dev: &back_to_dev
+  <<: *defaults
+  steps:
+    - checkout
+    - run:
+        name: Back to dev
+        command: |
+          composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
+          ~/.composer/vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY}
+
 # Declare all of the jobs we should run.
 jobs:
   run-coverage:
     <<: *code_coverage
   run-behat:
     <<: *behat
+  run-back-to-dev:
+    <<: *back_to_dev
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
   version: 2
+  after_release:
+    jobs:
+      - run-back-to-dev:
+          filters:
+            tags:
+              only:
+                - /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?$/
+            branches:
+              ignore:
+                - /.*/
   tests:
     jobs:
       - run-coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+# .github/workflows/release.yml
+name: Release
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag
+        uses: K-Phoen/semver-release-action@master
+        with:
+          release_branch: master
+          tag_format: "%major%.%minor%.%patch%"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Stanford Fields
 
+8.1.2
+--------------------------------------------------------------------------------
+_Release Date: 2020-04-16_
+
+* D8CORE-1644: Dev branch workflow (f163c12)
+* CSD-79 Created a date only widget for datetime fields (#7) (b426b29)
+* Update stanford_fields.info.yml (14cad23)
+
 8.x-1.1
 --------------------------------------------------------------------------------  
 _Release Date: 2019-11-19_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ _Release Date: 2020-04-16_
 * 8.1.2 (54f1a03)
 * D8CORE-1644: Dev branch workflow (f163c12)
 * CSD-79 Created a date only widget for datetime fields (#7) (b426b29)
-* Update stanford_fields.info.yml (14cad23)* D8CORE-1644: Dev branch workflow (f163c12)
+* Update stanford_fields.info.yml (14cad23)
+* D8CORE-1644: Dev branch workflow (f163c12)
 * CSD-79 Created a date only widget for datetime fields (#7) (b426b29)
 * Update stanford_fields.info.yml (14cad23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 --------------------------------------------------------------------------------
 _Release Date: 2020-04-16_
 
+* 8.1.2 (54f1a03)
 * D8CORE-1644: Dev branch workflow (f163c12)
+* CSD-79 Created a date only widget for datetime fields (#7) (b426b29)
+* Update stanford_fields.info.yml (14cad23)* D8CORE-1644: Dev branch workflow (f163c12)
 * CSD-79 Created a date only widget for datetime fields (#7) (b426b29)
 * Update stanford_fields.info.yml (14cad23)
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ Contribution / Collaboration
 ---
 
 You are welcome to contribute functionality, bug fixes, or documentation to this module. If you would like to suggest a fix or new functionality you may add a new issue to the GitHub issue queue or you may fork this repository and submit a pull request. For more help please see [GitHub's article on fork, branch, and pull requests](https://help.github.com/articles/using-pull-requests)
+
+
+Releases
+---
+
+Steps to build a new release:
+- Checkout the latest commit from the `8.x-1.x` branch.
+- Create a new branch for the release.
+- Commit any necessary changes to the release branch.
+  -  These may include, but are not necessarily limited to:
+    - Update the version in any `info.yml` files, including in any submodules.
+    - Update the CHANGELOG to reflect the changes made in the new release.
+- Make a PR to merge your release branch into `master`
+- Give the PR a semver-compliant label, e.g., (`patch`, `minor`, `major`).  This may happen automatically via Github actions (if a labeler action is configured).
+- When the PR is merged to `master`, a new tag will be created automatically, bumping the version by the semver label.
+- The github action is built from: [semver-release-action](https://github.com/K-Phoen/semver-release-action), and further documentation is available there.

--- a/config/schema/stanford_fields.schema.yml
+++ b/config/schema/stanford_fields.schema.yml
@@ -1,0 +1,19 @@
+field.widget.settings.datetime_year_only:
+  type: mapping
+  label: 'Year Only Date widget settings'
+  mapping:
+    increment:
+      type: integer
+      label: 'Time increments'
+    date_order:
+      type: string
+      label: 'Date part order'
+    time_type:
+      type: string
+      label: 'Time type'
+    start:
+      type: integer
+      label: 'Start Year'
+    end:
+      type: integer
+      label: 'End Year'

--- a/src/Plugin/Field/FieldWidget/DateYearOnlyWidget.php
+++ b/src/Plugin/Field/FieldWidget/DateYearOnlyWidget.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\stanford_fields\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\datetime\Plugin\Field\FieldWidget\DateTimeDatelistWidget;
+
+/**
+ * Plugin to provide a date widget that only collects the year.
+ *
+ * @FieldWidget(
+ *   id = "datetime_year_only",
+ *   label = @Translation("Year Only"),
+ *   field_types = {
+ *     "datetime"
+ *   }
+ * )
+ */
+class DateYearOnlyWidget extends DateTimeDatelistWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    $ten_years = 60 * 60 * 24 * 365 * 10;
+    $settings = [
+      'start' => date('Y', time() - $ten_years),
+      'end' => date('Y', time() + $ten_years),
+    ];
+    return $settings + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $summary[] = t('Years @start to @end', [
+      '@start' => $this->getSetting('start'),
+      '@end' => $this->getSetting('end'),
+    ]);
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element = parent::settingsForm($form, $form_state);
+    $element['date_order']['#type'] = 'hidden';
+
+    $year_range = range(1900, 2100);
+    $element['start'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Start Year'),
+      '#options' => array_combine($year_range, $year_range),
+      '#default_value' => $this->getSetting('start'),
+    ];
+    $element['end'] = [
+      '#type' => 'select',
+      '#title' => $this->t('End Year'),
+      '#options' => array_combine($year_range, $year_range),
+      '#default_value' => $this->getSetting('end'),
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    $element['value']['#date_part_order'] = ['year'];
+    $element['value']['#date_year_range'] = $this->getSetting('start') . ':' . $this->getSetting('end');
+    return $element;
+  }
+
+}

--- a/stanford_fields.info.yml
+++ b/stanford_fields.info.yml
@@ -3,6 +3,6 @@ type: module
 description: 'Field types, widgets and formatters to enhance Drupal and Contrib.'
 core_version_requirement: ^8 || ^9
 package: Stanford
-version: 8.x-1.1
+version: 8.x-1.2-dev
 dependencies:
  - drupal:field

--- a/stanford_fields.info.yml
+++ b/stanford_fields.info.yml
@@ -3,6 +3,6 @@ type: module
 description: 'Field types, widgets and formatters to enhance Drupal and Contrib.'
 core_version_requirement: ^8 || ^9
 package: Stanford
-version: 8.x-1.2-dev
+version: 8.x-1.2
 dependencies:
  - drupal:field

--- a/tests/src/Kernel/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\Tests\stanford_fields\Kernel\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget;
+
+/**
+ * Class DateYearOnlyWidgetTest
+ *
+ * @group
+ * @coversDefaultClass \Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget
+ */
+class DateYearOnlyWidgetTest extends KernelTestBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  protected static $modules = [
+    'system',
+    'path_alias',
+    'node',
+    'user',
+    'datetime',
+    'stanford_fields',
+    'field',
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('field_config');
+    $this->installEntitySchema('date_format');
+
+    NodeType::create(['type' => 'page'])->save();
+
+    $field_storage = FieldStorageConfig::create([
+      'field_name' => 'field_date',
+      'entity_type' => 'node',
+      'type' => 'datetime',
+      'cardinality' => 1,
+    ]);
+    $field_storage->save();
+
+    $field = FieldConfig::create([
+      'field_name' => 'field_date',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+    ]);
+    $field->save();
+  }
+
+  /**
+   * Test the entity form is displayed correctly.
+   */
+  public function testWidgetForm() {
+    $node = Node::create([
+      'type' => 'page',
+    ]);
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+    $entity_form_display = EntityFormDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'page',
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+    $entity_form_display->setComponent('field_date', ['type' => 'datetime_year_only'])
+      ->removeComponent('created')
+      ->save();
+
+    $form = [];
+    $form_state = new FormState();
+
+    $entity_form_display->buildForm($node, $form, $form_state);
+
+    $widget_value = $form['field_date']['widget'][0]['value'];
+    $ten_years = 60 * 60 * 24 * 365 * 10;
+    $range = date('Y', time() - $ten_years) . ':' . date('Y', time() + $ten_years);
+
+    $this->assertEqual('datelist', $widget_value['#type']);
+    $this->assertEqual($range, $widget_value['#date_year_range']);
+  }
+
+  /**
+   * Test the settings form and the summary.
+   */
+  public function testSettingsForm() {
+    $field_def = $this->createMock(FieldDefinitionInterface::class);
+    $config = [
+      'field_definition' => $field_def,
+      'settings' => [],
+      'third_party_settings' => [],
+    ];
+    $definition = [];
+    $widget = DateYearOnlyWidget::create(\Drupal::getContainer(), $config, '', $definition);
+    $summary = 'Years 2010 to 2030';
+    $this->assertEqual($summary, $widget->settingsSummary()[0]);
+
+    $form = [];
+    $form_state = new FormState();
+    $element = $widget->settingsForm($form, $form_state);
+
+    $ten_years = 60 * 60 * 24 * 365 * 10;
+
+    $this->assertEqual(date('Y', time() - $ten_years), $element['start']['#default_value']);
+    $this->assertEqual(date('Y', time() + $ten_years), $element['end']['#default_value']);
+  }
+
+}

--- a/tests/src/Unit/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
+++ b/tests/src/Unit/Plugin/Field/FieldWidget/DateYearOnlyWidgetTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\Tests\stanford_fields\Unit\Plugin\Field\FieldWidget;
+
+use Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class DateYearOnlyWidgetTest
+ *
+ * @group
+ * @coversDefaultClass \Drupal\stanford_fields\Plugin\Field\FieldWidget\DateYearOnlyWidget
+ */
+class DateYearOnlyWidgetTest extends UnitTestCase {
+
+  public function testDefaultSettings() {
+    $default_settings = DateYearOnlyWidget::defaultSettings();
+    $ten_years = (60 * 60 * 24 * 365 * 10);
+    $expected = [
+      'date_order' => 'YMD',
+      'increment' => '15',
+      'time_type' => '24',
+      'start' => date('Y', time() - $ten_years),
+      'end' => date('Y', time() + $ten_years),
+    ];
+    $this->assertArrayEquals($expected, $default_settings);
+  }
+
+}


### PR DESCRIPTION
# What
- Added date field widget to collect only the year.

# So what
- site builders can make forms easier when the year is the only needed data.

# Now what
- Deploy & Clear cache 

# New Requirements and Risks
- None

Changes:
https://github.com/SU-SWS/stanford_fields/compare/release-8.1.2