### PR TITLE
D8CORE-3476 Create a new view display mode specific for viewfields

### DIFF
--- a/src/Plugin/views/display/ViewFieldBlock.php
+++ b/src/Plugin/views/display/ViewFieldBlock.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\stanford_fields\Plugin\views\display;
+
+use Drupal\Core\Url;
+use Drupal\Component\Plugin\Discovery\CachedDiscoveryInterface;
+use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\Block\ViewsBlock;
+use Drupal\views\Plugin\views\display\Block;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * The plugin that handles a block.
+ *
+ * @ingroup views_display_plugins
+ *
+ * @ViewsDisplay(
+ *   id = "viewfield_block",
+ *   title = @Translation("View Field Block"),
+ *   help = @Translation("Identical to a block, but allows for granular viewfield settings."),
+ *   theme = "views_view",
+ *   register_theme = FALSE,
+ *   uses_hook_block = TRUE,
+ *   contextual_links_locations = {"block"},
+ *   admin = @Translation("Block")
+ * )
+ *
+ * @see \Drupal\views\Plugin\Block\ViewsBlock
+ * @see \Drupal\views\Plugin\Derivative\ViewsBlock
+ */
+class ViewFieldBlock extends Block {
+
+}

--- a/src/Plugin/views/display/ViewFieldBlock.php
+++ b/src/Plugin/views/display/ViewFieldBlock.php
@@ -2,14 +2,7 @@
 
 namespace Drupal\stanford_fields\Plugin\views\display;
 
-use Drupal\Core\Url;
-use Drupal\Component\Plugin\Discovery\CachedDiscoveryInterface;
-use Drupal\Core\Block\BlockManagerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\views\Plugin\Block\ViewsBlock;
 use Drupal\views\Plugin\views\display\Block;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * The plugin that handles a block.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- use the custom `viewfield_block` so that we can have different blocks allowed in the viewfield fields.
- It doesn't change any underlying functionality, it just allows for 2 identical block categories.

# Need Review By (Date)
- 3/3

# Urgency
- medium

# Steps to Test
1. Follow the steps in https://github.com/SU-SWS/stanford_profile/pull/370

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
