### PR TITLE
D8CORE-4693 Invalidate events whose end dates have recently passed

### DIFF
--- a/stanford_fields.module
+++ b/stanford_fields.module
@@ -41,5 +41,4 @@ function stanford_fields_field_storage_add_validate(&$form, FormStateInterface $
  */
 function stanford_fields_cron() {
   \Drupal::service('stanford_fields.field_cache')->invalidateDateFieldsCache();
-  \Drupal::state()->set('stanford_fields.dates_cleared', time() - 5);
 }

--- a/tests/src/Kernel/Service/FieldCacheTest.php
+++ b/tests/src/Kernel/Service/FieldCacheTest.php
@@ -69,6 +69,16 @@ class FieldCacheTest extends KernelTestBase {
       'bundle' => 'page',
       'field_name' => 'field_date',
     ])->save();
+    FieldStorageConfig::create([
+      'entity_type' => 'node',
+      'type' => 'daterange',
+      'field_name' => 'field_daterange',
+    ])->save();
+    FieldConfig::create([
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'field_name' => 'field_daterange',
+    ])->save();
     \Drupal::getContainer()->set('cache_tags.invalidator', $cache_invalidator);
   }
 
@@ -96,6 +106,21 @@ class FieldCacheTest extends KernelTestBase {
       ->set('stanford_fields.dates_cleared', time() - 60 * 60 * 24 * 4);
     $node->set('field_date', date($this->dateFieldFormat, time() - 60 * 60 * 24 * 3))
       ->save();
+    $this->invalidatedTags = [];
+    \Drupal::service('stanford_fields.field_cache')
+      ->invalidateDateFieldsCache();
+    $this->assertTrue(in_array('node:' . $node->id(), $this->invalidatedTags));
+
+    \Drupal::state()
+      ->set('stanford_fields.dates_cleared', time() - 60 * 60 * 24 * 4);
+    $daterange = [
+      'value' => date($this->dateFieldFormat, time() - 60 * 60 * 24 * 10),
+      'end_value' => date($this->dateFieldFormat, time() - 60 * 60 * 24),
+    ];
+    $node->set('field_date', [])
+      ->set('field_daterange', $daterange)
+      ->save();
+
     $this->invalidatedTags = [];
     \Drupal::service('stanford_fields.field_cache')
       ->invalidateDateFieldsCache();

--- a/tests/src/Kernel/Service/FieldCacheTest.php
+++ b/tests/src/Kernel/Service/FieldCacheTest.php
@@ -26,6 +26,7 @@ class FieldCacheTest extends KernelTestBase {
     'node',
     'user',
     'datetime',
+    'datetime_range',
     'field',
   ];
 
@@ -91,6 +92,8 @@ class FieldCacheTest extends KernelTestBase {
       ->invalidateDateFieldsCache();
     $this->assertEmpty($this->invalidatedTags);
 
+    \Drupal::state()
+      ->set('stanford_fields.dates_cleared', time() - 60 * 60 * 24 * 4);
     $node->set('field_date', date($this->dateFieldFormat, time() - 60 * 60 * 24 * 3))
       ->save();
     $this->invalidatedTags = [];


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adjusted the cache invalidation to also work on the date field end values.

# Need Review By (Date)
- 9/30

# Urgency
- medium

# Steps to Test
1. this one is tough to test, but the unit tests should indicate it's functioning as expected.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
