### PR TITLE
Asynchronously fetch Localist api data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,21 +47,6 @@ back_to_dev: &back_to_dev
           composer global require SU-SWS/stanford-caravan:dev-8.x-2.x
           ~/.composer/vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY}
 
-d8_codeception: &d8_codeception
-  <<: *defaults
-  steps:
-    - checkout:
-        path: /var/www/test
-    - run:
-        name: Run Codeception Tests
-        command: |
-          composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
-          ~/.composer/vendor/bin/sws-caravan codeception /var/www/html --extension-dir=/var/www/test
-    - store_test_results:
-        path: /var/www/html/artifacts/behat
-    - store_artifacts:
-        path: /var/www/html/artifacts
-
 d9_codeception: &d9_codeception
   <<: *defaults
   steps:
@@ -83,8 +68,6 @@ jobs:
     <<: *code_coverage
   run-back-to-dev:
     <<: *back_to_dev
-  run-d8-codeception:
-    <<: *d8_codeception
   run-d9-codeception:
     <<: *d9_codeception
 
@@ -104,7 +87,6 @@ workflows:
   tests:
     jobs:
       - run-coverage
-      - run-d8-codeception
       - run-d9-codeception
   # Re-test every sunday in case this code becomes stale.
   sundays:

--- a/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
+++ b/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
@@ -331,16 +331,20 @@ class LocalistUrlWidget extends LinkWidget {
   }
 
   /**
-   * Get the data from the
+   * Get the data from the localist API.
    *
    * @return array
+   *   API Data.
    */
-  protected function getApiData() {
+  protected function getApiData(): array {
+    // Data was already fetched.
     if ($this->apiData) {
       return $this->apiData;
     }
 
     $base_url = $this->getSetting('base_url');
+
+    // Check for some cached data before we fetch it all again.
     if ($cache = $this->cache->get("localist:$base_url")) {
       $this->apiData = $cache->data;
       return $this->apiData;
@@ -355,7 +359,7 @@ class LocalistUrlWidget extends LinkWidget {
    * @return array
    *   Keyed array of api data.
    */
-  protected function fetchApiData() {
+  protected function fetchApiData(): array {
     $base_url = $this->getSetting('base_url');
     $options = ['base_uri' => $base_url, 'query' => ['pp' => 1]];
     $promises = [
@@ -390,7 +394,7 @@ class LocalistUrlWidget extends LinkWidget {
    * @return array
    *   Indexed array of api data.
    */
-  protected function fetchPagedApiData($endpoint, $total_count){
+  protected function fetchPagedApiData($endpoint, $total_count): array {
     $base_url = $this->getSetting('base_url');
     $options = ['base_uri' => $base_url, 'query' => ['pp' => 100]];
 
@@ -402,7 +406,7 @@ class LocalistUrlWidget extends LinkWidget {
     $paged_data = self::unwrapAsyncRequests($paged_data);
 
     $data = [];
-    foreach($paged_data as $page){
+    foreach ($paged_data as $page) {
       unset($page['page']);
       $key = key($page);
       $data = array_merge($data, $page[$key]);
@@ -413,18 +417,19 @@ class LocalistUrlWidget extends LinkWidget {
   /**
    * Unwrap async promises and decode their body data.
    *
-   * @param \GuzzleHttp\Promise\Promise[] $promises
+   * @param \GuzzleHttp\Promise\PromiseInterface[] $promises
    *   Associative array of Guzzle promises.
    *
    * @return array
    *   Associative array of json decoded data.
    */
-  protected static function unwrapAsyncRequests(array $promises){
+  protected static function unwrapAsyncRequests(array $promises): array {
     $promises = Utils::unwrap($promises);
     /** @var \GuzzleHttp\Psr7\Response $response */
     foreach ($promises as $key => &$response) {
       $response = json_decode((string) $response->getBody(), TRUE);
     }
+
     return $promises;
   }
 

--- a/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
+++ b/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
@@ -42,6 +42,8 @@ class LocalistUrlWidget extends LinkWidget {
   protected $cache;
 
   /**
+   * API data from Localist.
+   *
    * @var array
    */
   protected $apiData = [];
@@ -387,7 +389,7 @@ class LocalistUrlWidget extends LinkWidget {
    * Given the endpoint and count, async fetch from the API all pages.
    *
    * @param string $endpoint
-   *   Localist API Endpoint
+   *   Localist API Endpoint.
    * @param int $total_count
    *   Total number of items to chunk up.
    *
@@ -426,7 +428,7 @@ class LocalistUrlWidget extends LinkWidget {
   protected static function unwrapAsyncRequests(array $promises): array {
     $promises = Utils::unwrap($promises);
     /** @var \GuzzleHttp\Psr7\Response $response */
-    foreach ($promises as $key => &$response) {
+    foreach ($promises as &$response) {
       $response = json_decode((string) $response->getBody(), TRUE);
     }
 

--- a/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
+++ b/src/Plugin/Field/FieldWidget/LocalistUrlWidget.php
@@ -3,6 +3,7 @@
 namespace Drupal\stanford_fields\Plugin\Field\FieldWidget;
 
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -347,7 +348,7 @@ class LocalistUrlWidget extends LinkWidget {
     $base_url = $this->getSetting('base_url');
 
     // Check for some cached data before we fetch it all again.
-    if ($cache = $this->cache->get("localist:$base_url")) {
+    if ($cache = $this->cache->get("localist_api:$base_url")) {
       $this->apiData = $cache->data;
       return $this->apiData;
     }
@@ -381,7 +382,7 @@ class LocalistUrlWidget extends LinkWidget {
 
       $this->apiData[$key] = $this->fetchPagedApiData($key, $response['page']['total']);
     }
-    $this->cache->set("localist:$base_url", $this->apiData);
+    $this->cache->set("localist_api:$base_url", $this->apiData, Cache::PERMANENT, ['localist_api']);
     return $this->apiData;
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Improve API fetching by using asynchronous Guzzle requests.
- Decreased non-cached data fetching to 1/5 original time (55 seconds -> 10.5 seconds)

# Need Review By (Date)
- 3/16

# Urgency
- high

# Steps to Test
1. checkout this branch
2. view the localist importer configuration page
3. verify it doesn't take as long as it used to.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
