### PR TITLE
SUL23-818 | add hook to allow for overwriting custom font awesome icon help text

### DIFF
--- a/src/Hook/StanfordFieldsHooks.php
+++ b/src/Hook/StanfordFieldsHooks.php
@@ -85,12 +85,16 @@ class StanfordFieldsHooks {
   }
 
   /**
-   * Hides the font awesome additional settings options.
+   * Hides the font awesome additional settings options
+   * and replace the default help text with field-specific help text.
    */
   #[Hook('field_widget_complete_fontawesome_icon_widget_form_alter')]
   public function fontawesomeIconWidgetFormAlter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
     $hidden_settings = $context['widget']->getThirdPartySetting('stanford_fields', 'hidden_settings', []);
     foreach (Element::children($field_widget_complete_form['widget']) as $delta) {
+      if (isset($field_widget_complete_form['widget'][$delta]['icon_name']) && $field_widget_complete_form['widget'][$delta]['#description']) {
+        $field_widget_complete_form['widget'][$delta]['icon_name']['#description'] = $field_widget_complete_form['widget'][$delta]['#description'];
+      }
       foreach ($hidden_settings as $hidden_setting) {
         $field_widget_complete_form['widget'][$delta]['settings'][$hidden_setting]['#access'] = FALSE;
       }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUL23-818 | add hook to allow for overwriting with custom font awesome icon help text

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Import stanford_profile config in https://github.com/SU-SWS/stanford_profile/pull/994
2. Review code

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? 
- Yes, see https://github.com/SU-SWS/stanford_profile/pull/994

# Associated Issues and/or People
- SUL23-818
- https://github.com/SU-SWS/stanford_profile/pull/994